### PR TITLE
Fix for test gentoo/stage3-amd64

### DIFF
--- a/plat.conf
+++ b/plat.conf
@@ -38,7 +38,7 @@ archlinux:latest|
 mageia|dnf update -y |dnf install -y |openssl,socat,idn,curl|
 
 
-gentoo/stage3-amd64| emerge --sync | ACCEPT_KEYWORDS="~amd64" emerge | net-misc/curl,sys-process/vixie-cron,net-misc/socat
+gentoo/stage3-amd64| emerge --sync | ACCEPT_KEYWORDS="~amd64" emerge | net-misc/curl,virtual/cron,net-misc/socat
 
 -clearlinux||swupd bundle-add|cronie,socat,curl,devpkg-libidn|
 clearlinux:latest|


### PR DESCRIPTION
- Package sys-process/vixie-cron was removed, causing test to fail. Replace it with virtual/cron.
Error message:
emerge: there are no ebuilds to satisfy "sys-process/vixie-cron".
- Refer to https://bugs.gentoo.org/694036