### PR TITLE
allow testing acme.sh forks; fixes, cleanups

### DIFF
--- a/letest.sh
+++ b/letest.sh
@@ -2,6 +2,8 @@
 
 STAGE=1
 
+: "${BRANCH:=master}"
+
 : "${ACMESH_REPO:=https://github.com/acmesh-official/acme.sh}"
 lezip="$ACMESH_REPO/archive"
 legit="$ACMESH_REPO/"
@@ -756,9 +758,6 @@ _setup() {
   fi
   if [ -d acme.sh ] ; then
     rm -rf acme.sh 
-  fi
-  if [ ! "$BRANCH" ] ; then
-    BRANCH="master"
   fi
   _info "Testing branch: $BRANCH"
   if ! "${ACMETEST_USE_GIT:-false}" && command -v tar > /dev/null ; then

--- a/letest.sh
+++ b/letest.sh
@@ -60,14 +60,12 @@ _API_HOST="$(echo "$STAGE_CA" | cut -d : -f 2 | tr -d '/')"
 
 _isIPv4() {
   for seg in $(echo "$1" | tr '.' ' '); do
-    if [ "$(echo "$seg" | tr -d 0-9)" ]; then
-      #not all number
+    case "$seg" in
+      (*[!0-9]*) return 1 ;; #not all number
+    esac
+    if ! [ $seg -ge 0 ] || ! [ $seg -lt 256 ]; then
       return 1
     fi
-    if [ $seg -ge 0 ] && [ $seg -lt 256 ]; then
-      continue
-    fi
-    return 1
   done
   return 0
 }

--- a/letest.sh
+++ b/letest.sh
@@ -765,12 +765,12 @@ _setup() {
   _info "Testing branch: $BRANCH"
   if ! "${ACMETEST_USE_GIT:-false}" && command -v tar > /dev/null ; then
     link="$lezip/$BRANCH.tar.gz"
-    curl -OL "$link" >/dev/null 2>&1
+    (set -x; curl -OL "$link" >/dev/null 2>&1)
     tar xzf "$BRANCH.tar.gz"  >/dev/null 2>&1
     mv "acme.sh-$BRANCH" acme.sh
   elif command -v git > /dev/null ; then
     rm -rf acme.sh
-    git clone $legit -b $BRANCH
+    (set -x; git clone $legit -b $BRANCH)
   else
     _err "Can not get acme.sh source code. tar or git must be installed"
     return 1

--- a/letest.sh
+++ b/letest.sh
@@ -2,8 +2,9 @@
 
 STAGE=1
 
-lezip="https://github.com/acmesh-official/acme.sh/archive"
-legit="https://github.com/acmesh-official/acme.sh.git"
+: "${ACMESH_REPO:=https://github.com/acmesh-official/acme.sh}"
+lezip="$ACMESH_REPO/archive"
+legit="$ACMESH_REPO.git"
 
 PROJECT="https://github.com/acmesh-official/acmetest"
 
@@ -762,7 +763,7 @@ _setup() {
     BRANCH="master"
   fi
   _info "Testing branch: $BRANCH"
-  if command -v tar > /dev/null ; then
+  if ! "${ACMETEST_USE_GIT:-false}" && command -v tar > /dev/null ; then
     link="$lezip/$BRANCH.tar.gz"
     curl -OL "$link" >/dev/null 2>&1
     tar xzf "$BRANCH.tar.gz"  >/dev/null 2>&1

--- a/letest.sh
+++ b/letest.sh
@@ -177,7 +177,7 @@ _date_u () {
 
 #a + b
 _math() {
-  _m_opts="$@"
+  _m_opts=$*
   printf "%s" "$(($_m_opts))"
 }
 

--- a/letest.sh
+++ b/letest.sh
@@ -309,7 +309,7 @@ _digest() {
   
   if [ "$alg" = "sha256" ] ; then
     if [ "$outputhex" ] ; then
-      echo $(openssl dgst -sha256 -hex | cut -d = -f 2)
+      openssl dgst -sha256 -hex | cut -d = -f 2
     else
       openssl dgst -sha256 -binary | _base64
     fi
@@ -600,11 +600,11 @@ _assertcert() {
   subname="$2"
   issuername="$3"
   printf "$filename is cert ? "
-  subj="$(echo  $(openssl x509  -in $filename  -text  -noout | grep 'Subject:.*CN *=' | _egrep_o  " CN *=.*" | cut -d '=' -f 2 | cut -d / -f 1))"
+  subj="$(openssl x509  -in $filename  -text  -noout | grep 'Subject:.*CN *=' | _egrep_o  " CN *=.*" | cut -d '=' -f 2 | cut -d / -f 1)"
   printf "'$subj'"
   if _contains "$subj" "$subname" || _isIP "$subname"; then
     if [ "$issuername" ] ; then
-      issuer="$(echo $(openssl x509 -in $filename -text -noout | grep 'Issuer:' | _egrep_o "CN *=[^,]*" | cut -d = -f 2))"
+      issuer="$(openssl x509 -in $filename -text -noout | grep 'Issuer:' | _egrep_o "CN *=[^,]*" | cut -d = -f 2)"
       printf " '$issuer'"
       if ! _contains "$issuer" "$issuername"; then
         __fail "Expected issuer is: '$issuername', but was: '$issuer'"

--- a/letest.sh
+++ b/letest.sh
@@ -438,7 +438,7 @@ if [ -z "$TestingDomain" ]; then
     while [ $_wait -le $MaxWait ]; do
       sleep 10
       _wait=$((_wait + 10))
-      ng_domain_1="$(cat "$ng_temp_1" | grep https:// | grep trycloudflare.com | grep -v api.trycloudflare.com | head -1 | cut -d '|' -f 2 | tr -d ' ' | cut -d '/' -f 3)"
+      ng_domain_1="$(grep -- 'https://.*trycloudflare.com' "$ng_temp_1" | grep -v api.trycloudflare.com | head -1 | cut -d '|' -f 2 | tr -d ' ' | cut -d '/' -f 3)"
       _info "ng_domain_1" "$ng_domain_1"
 
       if [ -z "$ng_domain_1" ] ; then
@@ -681,7 +681,7 @@ _assertequals() {
 _assertfileequals(){
   file1="$1"
   file2="$2"
-  if [ "$(cat "$file1" | _digest  sha256)" = "$(cat "$file2" | _digest  sha256)" ] ; then
+  if [ "$(_digest  sha256 < "$file1")" = "$(_digest  sha256 < "$file2")" ] ; then
     printf -- "'$file1' equals '$2'"
     __ok
   else

--- a/letest.sh
+++ b/letest.sh
@@ -124,7 +124,7 @@ fi
 
 
 __green() {
-  if [ "${__INTERACTIVE}${ACME_NO_COLOR:-0}" = "10" -o "${ACME_FORCE_COLOR}" = "1" ]; then
+  if [ "${__INTERACTIVE}${ACME_NO_COLOR:-0}" = "10" ] || [ "${ACME_FORCE_COLOR}" = "1" ]; then
     printf '\033[1;31;32m%b\033[0m' "$1"
     return
   fi
@@ -132,7 +132,7 @@ __green() {
 }
 
 __red() {
-  if [ "${__INTERACTIVE}${ACME_NO_COLOR:-0}" = "10" -o "${ACME_FORCE_COLOR}" = "1" ]; then
+  if [ "${__INTERACTIVE}${ACME_NO_COLOR:-0}" = "10" ] || [ "${ACME_FORCE_COLOR}" = "1" ]; then
     printf '\033[1;31;40m%b\033[0m' "$1"
     return
   fi

--- a/letest.sh
+++ b/letest.sh
@@ -60,7 +60,7 @@ _API_HOST="$(echo "$STAGE_CA" | cut -d : -f 2 | tr -d '/')"
 
 _isIPv4() {
   for seg in $(echo "$1" | tr '.' ' '); do
-    if [ "$(echo "$seg" | tr -d [0-9])" ]; then
+    if [ "$(echo "$seg" | tr -d 0-9)" ]; then
       #not all number
       return 1
     fi
@@ -1599,8 +1599,8 @@ le_test_shell() {
   _assertText "1648800633" "$($lehome/$PROJECT_ENTRY _date2time "2022-04-01T08:10:33Z")"  ||  return
   _assertText "1648800633" "$($lehome/$PROJECT_ENTRY _date2time "2022-04-01 08:10:33")"   ||  return
   _assertText "2022-04-01T08:10:33Z" "$($lehome/$PROJECT_ENTRY _time2str "1648800633")"   ||  return
-  _assertText "ABC" "$(echo abc | tr [a-z] [A-Z])"   ||  return
-  _assertText "ABC" "$(echo abc | tr '[a-z]' '[A-Z]')"   ||  return
+  _assertText "ABC" "$(echo abc | tr 'a-z' 'A-Z')"   ||  return
+  _assertText "ABC" "$(echo abc | tr 'a-z' 'A-Z')"   ||  return
 }
 
 

--- a/letest.sh
+++ b/letest.sh
@@ -4,7 +4,7 @@ STAGE=1
 
 : "${ACMESH_REPO:=https://github.com/acmesh-official/acme.sh}"
 lezip="$ACMESH_REPO/archive"
-legit="$ACMESH_REPO.git"
+legit="$ACMESH_REPO/"
 
 PROJECT="https://github.com/acmesh-official/acmetest"
 

--- a/letest.sh
+++ b/letest.sh
@@ -225,7 +225,11 @@ _exists() {
 _contains() {
   _str="$1"
   _sub="$2"
-  echo "$_str" | grep -- "$_sub" >/dev/null 2>&1
+  case "$_str" in
+    (*"$_sub"*) return 0 ;;
+  esac
+  return 1
+  echo "$_str" | grep -F -- "$_sub" >/dev/null 2>&1
 }
 
 _mktemp() {
@@ -815,7 +819,7 @@ le_test_install() {
   
   _assertexists "$lehome/$PROJECT_ENTRY" || return
   _c_entry="$(crontab -l | grep $PROJECT_ENTRY)"
-  _assertcmd "_contains '$_c_entry' '0 \\* \\* \\* \"$lehome\"/$PROJECT_ENTRY --cron --home \"$lehome\" > /dev/null'" || return
+  _assertcmd "_contains '$_c_entry' '0 * * * \"$lehome\"/$PROJECT_ENTRY --cron --home \"$lehome\" > /dev/null'" || return
   _assertcmd "$lehome/$PROJECT_ENTRY --uninstall  > /dev/null" ||  return
 }
 
@@ -845,7 +849,7 @@ le_test_installtodir() {
   
   _assertexists "$lehome/$PROJECT_ENTRY" ||  return
   _c_entry="$(crontab -l | grep $PROJECT_ENTRY)"
-  _assertcmd "_contains '$_c_entry' '0 \\* \\* \\* \"$lehome\"/$PROJECT_ENTRY --cron --home \"$lehome\" > /dev/null'" || return
+  _assertcmd "_contains '$_c_entry' '0 * * * \"$lehome\"/$PROJECT_ENTRY --cron --home \"$lehome\" > /dev/null'" || return
   _assertcmd "$lehome/$PROJECT_ENTRY --uninstall" ||  return
   if [ -z "$DEBUG" ]; then
     rm -rf $lehome
@@ -884,7 +888,7 @@ le_test_install_config_home() {
   
   _assertexists "$lehome/$PROJECT_ENTRY" || return
   _c_entry="$(crontab -l | grep $PROJECT_ENTRY)"
-  _assertcmd "_contains '$_c_entry' '0 \\* \\* \\* \"$lehome\"/$PROJECT_ENTRY --cron --home \"$lehome\" --config-home \"$confighome\" > /dev/null'" || return
+  _assertcmd "_contains '$_c_entry' '0 * * * \"$lehome\"/$PROJECT_ENTRY --cron --home \"$lehome\" --config-home \"$confighome\" > /dev/null'" || return
   _assertexists "$confighome/account.conf" || return
   _assertnotexists "$lehome/account.conf" || return
   _assertcmd "$lehome/$PROJECT_ENTRY --cron --config-home $confighome > /dev/null" ||  return


### PR DESCRIPTION
This allows, for example,
```
ACMETEST_USE_GIT=true ACMESH_REPO=file:///src/acme.sh BRANCH=dev sh  ./letest.sh
```

i.e. test local repos or forks of `acmetest` on github.

I've also fixed some shellcheck problems and cleaned up some implementation details.