### PR TITLE
Force Kali Linux to use a single APT mirror for install and update

### DIFF
--- a/plat.conf
+++ b/plat.conf
@@ -32,7 +32,7 @@ alpine:latest|
 oraclelinux:8|
 
 
-kalilinux/kali-last-release|apt-get -y update|apt-get -y install|openssl,cron,socat,curl,idn,wget|
+kalilinux/kali-last-release|sed -i -e "s/http.kali.org/mirrors.ocf.berkeley.edu/g" /etc/apt/sources.list && apt-get -y update|apt-get -y install|openssl,cron,socat,curl,idn,wget|
 
 -archlinux||pacman  -Sy  --overwrite "*" --noconfirm --noprogressbar|openssl,cronie,socat,libidn,unzip,wget,curl|
 archlinux:latest|


### PR DESCRIPTION
This avoids an issue where apt-get update and apt-get install commands hit different mirrors with different versions of packages, causing install to fail.

This should fix the DNS workflow for https://github.com/acmesh-official/acme.sh/pull/4542