### PR TITLE
add --allowerasing to almalinux

### DIFF
--- a/plat.conf
+++ b/plat.conf
@@ -6,31 +6,23 @@ ubuntu:latest|
 -debian|apt-get -y update |apt-get -y install|openssl,cron,socat,curl,idn,wget|
 debian:latest|
 
-
 -centos|yum  -y update    |yum  -y install   |openssl,crontabs,socat,curl,wget|
 centos:7|
 
--almalinux|yum  -y update    |yum  -y install   |openssl,crontabs,socat,curl,wget|
+-almalinux|yum  -y update    |yum  -y --allowerasing install |openssl,cronie,socat,curl,wget|
 almalinux:latest|
-
 
 -fedora|yum  -y update    |yum  -y install   |tar,openssl,crontabs,socat,curl,wget|
 fedora:latest|
 
-
-
-
 -opensuse/leap|zypper rr repo-non-oss repo-update-non-oss && zypper update -y |zypper install  -y  |tar,openssl,cron,socat,curl,libidn-tools,gzip,unzip,wget|
 opensuse/leap:latest|
-
 
 -alpine|apk update -f|apk --no-cache add -f|openssl,curl,socat,libidn,libc6-compat,wget|
 alpine:latest|
 
-
 -oraclelinux||dnf install -y   |tar,openssl,cronie,socat,curl,wget|
 oraclelinux:8|
-
 
 kalilinux/kali-last-release|apt-get -y update|apt-get -y install|openssl,cron,socat,curl,idn,wget|
 
@@ -39,9 +31,7 @@ archlinux:latest|
 
 mageia|dnf update -y |dnf install -y |openssl,socat,idn,curl,wget|
 
-
 gentoo/stage3| emerge --sync | emerge | net-misc/curl,virtual/cron,net-misc/socat,wget
 
 -clearlinux||swupd bundle-add|cronie,socat,curl,devpkg-libidn,wget|
 clearlinux:latest|
-


### PR DESCRIPTION
```
sh-5.1# yum -y install curl
Last metadata expiration check: 0:00:10 ago on Sat May 13 20:38:44 2023. Error:
 Problem: problem with installed package curl-minimal-7.76.1-23.el9_2.1.aarch64
  - package curl-minimal-7.76.1-23.el9_2.1.aarch64 conflicts with curl provided by curl-7.76.1-23.el9_2.1.aarch64
  - package curl-minimal-7.76.1-23.el9.aarch64 conflicts with curl provided by curl-7.76.1-23.el9_2.1.aarch64
  - cannot install the best candidate for the job (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```