### PR TITLE
bump vmactions/openbsd-vm to v0.1.2

### DIFF
--- a/.github/workflows/OpenBSD.yml
+++ b/.github/workflows/OpenBSD.yml
@@ -37,7 +37,7 @@ jobs:
         port: 8080
     - name: Set envs
       run: echo "TestingDomain=${{steps.tunnel.outputs.server}}" >> $GITHUB_ENV
-    - uses: vmactions/openbsd-vm@v0
+    - uses: vmactions/openbsd-vm@v0.1.2
       with:
         envs: 'TestingDomain TEST_PREFERRED_CHAIN TEST_ACME_Server'
         nat: |


### PR DESCRIPTION
exec shell: bash run.sh installRsyncInVM
/bin/bash
Config file: openbsd-7.2.conf
quirks-6.42 signed on 2023-04-06T19:16:59Z
Ustar [https://cdn.openbsd.org/pub/OpenBSD/7.2/packages/amd64/rsync-3.2.5pl0.tgz][bin/rsync]: Premature end of archive pkg_add: Installation of rsync-3.2.5pl0 failed, partial installation recorded as partial-rsync-3.2.5pl0