### PR TITLE
Randomize record content letest

### DIFF
--- a/letest.sh
+++ b/letest.sh
@@ -1501,8 +1501,9 @@ le_test_dnsapi() {
      _initpath $TestingDomain
      addcommand="${api}_add"
      rmcommand="${api}_rm"
-     _assertcmd "$addcommand acmetestXyzRandomName.$TestingDomain acmeTestTxtRecord"  ||  return
-     _assertcmd "$rmcommand  acmetestXyzRandomName.$TestingDomain acmeTestTxtRecord"  ||  return
+     record_content="acmeTestTxtRecord_$(date +%N)"
+     _assertcmd "$addcommand acmetestXyzRandomName.$TestingDomain $record_content"  ||  return
+     _assertcmd "$rmcommand  acmetestXyzRandomName.$TestingDomain $record_content"  ||  return
   ) || return
 
 }

--- a/letest.sh
+++ b/letest.sh
@@ -1501,7 +1501,8 @@ le_test_dnsapi() {
      _initpath $TestingDomain
      addcommand="${api}_add"
      rmcommand="${api}_rm"
-     record_content="acmeTestTxtRecord_$(date +%N)"
+     random_string="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c10)"
+     record_content="acmeTestTxtRecord_$random_string"
      _assertcmd "$addcommand acmetestXyzRandomName.$TestingDomain $record_content"  ||  return
      _assertcmd "$rmcommand  acmetestXyzRandomName.$TestingDomain $record_content"  ||  return
   ) || return


### PR DESCRIPTION
This change set adds a random string suffix to TXT DNS record in le_dns_api() function (in letest.sh). Although the tests run sequentially, for some reason, I was encountering record conflict when running the DNS tests in acme.sh (PR: https://github.com/acmesh-official/acme.sh/pull/5110, action: https://github.com/ionos-cloud/acme.sh/actions/runs/8893387756/job/24419446631). It seems like sometimes a test would start inserting before the previous tests cleans up the record. I guess it would not hurt having a random content for the record content. 