### PR TITLE
add libiconv package

### DIFF
--- a/.github/workflows/OpenBSD.yml
+++ b/.github/workflows/OpenBSD.yml
@@ -43,7 +43,7 @@ jobs:
         envs: 'TestingDomain TEST_PREFERRED_CHAIN TEST_ACME_Server'
         nat: |
           "8080": "80"
-        prepare: pkg_add socat curl libnghttp2
+        prepare: pkg_add socat curl libiconv libnghttp2
         usesh: true
         copyback: false
         release: ${{ matrix.release }}


### PR DESCRIPTION
acme.sh dnsapi/dns_edgedns.sh invokes iconv(1) which is not provided by OpenBSD in the base system.  Adding the libiconv package provides this tool.

This should also help address https://github.com/acmesh-official/acme.sh/pull/4350, albeit indirectly: it looks like that PR cannot be merged because the OpenBSD test fails despite the PR not actually changing anything having to do with iconv.  That is, I suspect that the test for OpenBSD failed (or would have failed, had it been run?) prior to that PR being issued.